### PR TITLE
Factor out tests into suite objects as values

### DIFF
--- a/core-tests/shared/src/test/scala/zio/macros/delegate/DelegateSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/macros/delegate/DelegateSpec.scala
@@ -16,156 +16,172 @@
 package zio.macros.delegate
 
 import zio.UIO
-import zio.test.{ DefaultRunnableSpec, assert, suite, testM }
 import zio.test.Assertion.equalTo
+import zio.test.{ DefaultRunnableSpec, assert, suite, testM }
+import zio.test.TestAspect.ignore
 
 object DelegateSpec
     extends DefaultRunnableSpec(
       suite("delegate annotation")(
-        testM("should automatically extend traits") {
-          trait Foo {
-            def a: Int
-          }
-
-          for {
-            inner <- UIO(new Foo {
-                      def a = 3
-                    })
-            outer <- UIO {
-                      class Bar(@delegate foo: Foo)
-                      new Bar(inner)
-                    }
-          } yield assert(outer.a, equalTo(3))
-        },
-        testM("should allow overrides") {
-          trait Foo {
-            def a: Int = 3
-          }
-
-          for {
-            inner <- UIO(new Foo {})
-            outer <- UIO {
-                      class Bar(@delegate foo: Foo) {
-                        override def a = 4
-                      }
-                      new Bar(inner)
-                    }
-          } yield assert(outer.a, equalTo(4))
-        },
-        testM("should handle final methods") {
-          trait Foo {
-            final def a: Int = 3
-          }
-
-          for {
-            inner <- UIO(new Foo {})
-            outer <- UIO {
-                      class Bar(@delegate foo: Foo) extends Foo
-                      new Bar(inner)
-                    }
-          } yield assert(outer.a, equalTo(3))
-        },
-        /*
-// TODO: this is an example that triggers this issue https://github.com/milessabin/shapeless/issues/614
-        testM("should handle locally visible symbols") {
-          object Test {
-            trait Foo {
-              final def a: Int = 3
-            }
-          }
-
-          for {
-            inner <- UIO(new Test.Foo {})
-            outer <- UIO {
-              class Bar(@delegate(verbose = true) foo: Test.Foo)
-              new Bar(inner)
-            }
-          } yield assert(outer.a, equalTo(3))
-        },
-         */
-        testM("should work with abstract classes when explicitly extending") {
-          abstract class Foo {
-            def a: Int
-          }
-
-          for {
-            inner <- UIO(new Foo {
-                      def a = 3
-                    })
-            outer <- UIO {
-                      class Bar(@delegate foo: Foo) extends Foo
-                      new Bar(inner)
-                    }
-          } yield assert(outer.a, equalTo(3))
-        },
-        /*
-        suite("should handle methods with same name but different signatures")(
-          testM("case 1") {
-            trait Foo {
-              def a(i: Int): Int = 3
-            }
-
-            for {
-              inner <- UIO(new Foo {})
-              outer <- UIO {
-                        class Bar(@delegate foo: Foo) {
-                          def a(s: String) = "bar"
-                        }
-                        new Bar(inner)
-                      }
-            } yield assert(outer.a(""), equalTo("bar")) && assert(outer.a(0), equalTo(3))
-          }, // TODO: does not compile on 2.11 only, see issue https://github.com/zio/zio-macros/issues/47
-          testM("case 2") {
-            trait Foo {
-              def a(i: Int): Int = 3
-            }
-            trait Foo1 extends Foo {
-              def a(s: String) = "bar"
-            }
-
-            for {
-              inner <- UIO(new Foo1 {})
-              outer <- UIO {
-                        class Bar(@delegate foo: Foo1)
-                        new Bar(inner)
-                      }
-            } yield assert(outer.a(""), equalTo("bar")) && assert(outer.a(0), equalTo(3))
-          } // TODO: does not compile on 2.11 only, see issue https://github.com/zio/zio-macros/issues/48
-        ),
-         */
-        testM("should handle type parameters") {
-          trait Foo[A] {
-            def a: A
-          }
-          trait Bar extends Foo[Int] {
-            def a: Int = 1
-          }
-
-          for {
-            inner <- UIO(new Bar {})
-            outer <- UIO {
-                      class Baz(@delegate bar: Bar)
-                      new Baz(inner)
-                    }
-          } yield assert(outer.a, equalTo(1))
-        }
-        /*
-// TODO: test case for https://github.com/zio/zio-macros/issues/17
-        testM("should handle type parameters on resulting class") {
-          trait Foo[A] {
-            def a: A
-          }
-
-          for {
-            inner <- UIO(new Foo[Int] {
-              val a = 1
-            })
-            outer <- UIO {
-              class Bar[A](@delegate foo: Foo[A])
-              new Bar[Int[(inner)
-            }
-          } yield assert(outer.a, equalTo(1))
-        }
-       */
+        DelegateSuite.automaticallyExtendTraits,
+        DelegateSuite.allowOverrides,
+        DelegateSuite.handleFinalMethods,
+        DelegateSuite.extendingAbstractClasses,
+        DelegateSuite.methodsWithSameName,
+        DelegateSuite.typeParameters
       )
     )
+
+object DelegateSuite {
+
+  val automaticallyExtendTraits = testM("should automatically extend traits") {
+    trait Foo {
+      def a: Int
+    }
+
+    for {
+      inner <- UIO(new Foo {
+                def a = 3
+              })
+      outer <- UIO {
+                class Bar(@delegate foo: Foo)
+                new Bar(inner)
+              }
+    } yield assert(outer.a, equalTo(3))
+  }
+
+  val allowOverrides = testM("should allow overrides") {
+    trait Foo {
+      def a: Int = 3
+    }
+
+    for {
+      inner <- UIO(new Foo {})
+      outer <- UIO {
+                class Bar(@delegate foo: Foo) {
+                  override def a = 4
+                }
+                new Bar(inner)
+              }
+    } yield assert(outer.a, equalTo(4))
+  }
+
+  val handleFinalMethods = testM("should handle final methods") {
+    trait Foo {
+      final def a: Int = 3
+    }
+
+    for {
+      inner <- UIO(new Foo {})
+      outer <- UIO {
+                class Bar(@delegate foo: Foo) extends Foo
+                new Bar(inner)
+              }
+    } yield assert(outer.a, equalTo(3))
+  }
+
+  /*
+  // TODO: this is an example that triggers this issue https://github.com/milessabin/shapeless/issues/614
+  val locallyVisibleSymbols = testM("should handle locally visible symbols") {
+    object Test {
+      trait Foo {
+        final def a: Int = 3
+      }
+    }
+
+    for {
+      inner <- UIO(new Test.Foo {})
+      outer <- UIO {
+                class Bar(@delegate(verbose = true) foo: Test.Foo)
+                new Bar(inner)
+              }
+    } yield assert(outer.a, equalTo(3))
+  }
+   */
+
+  val extendingAbstractClasses = testM("should work with abstract classes when explicitly extending") {
+    abstract class Foo {
+      def a: Int
+    }
+
+    for {
+      inner <- UIO(new Foo {
+                def a = 3
+              })
+      outer <- UIO {
+                class Bar(@delegate foo: Foo) extends Foo
+                new Bar(inner)
+              }
+    } yield assert(outer.a, equalTo(3))
+  }
+
+  val methodsWithSameName = suite("should handle methods with same name but different signatures")(
+    testM("case 1") {
+      trait Foo {
+        def a(i: Int): Int = 3
+      }
+
+      for {
+        inner <- UIO(new Foo {})
+        outer <- UIO {
+                  class Bar(@delegate foo: Foo) {
+                    def a(s: String) = "bar"
+                  }
+                  new Bar(inner)
+                }
+      } yield assert(outer.a(""), equalTo("bar")) && assert(outer.a(0), equalTo(3))
+    } @@ ignore, // TODO: Fails on 2.11 with ClassCastException
+    testM("case 2") {
+      trait Foo {
+        def a(i: Int): Int = 3
+      }
+      trait Foo1 extends Foo {
+        def a(s: String) = "bar"
+      }
+
+      for {
+        inner <- UIO(new Foo1 {})
+        outer <- UIO {
+                  class Bar(@delegate foo: Foo1)
+                  new Bar(inner)
+                }
+      } yield assert(outer.a(""), equalTo("bar")) && assert(outer.a(0), equalTo(3))
+    }
+  )
+
+  val typeParameters = testM("should handle type parameters") {
+    trait Foo[A] {
+      def a: A
+    }
+    trait Bar extends Foo[Int] {
+      def a: Int = 1
+    }
+
+    for {
+      inner <- UIO(new Bar {})
+      outer <- UIO {
+                class Baz(@delegate bar: Bar)
+                new Baz(inner)
+              }
+    } yield assert(outer.a, equalTo(1))
+  }
+
+  /*
+  // TODO: test case for https://github.com/zio/zio-macros/issues/17
+  val typeParametersOnResultingClass = testM("should handle type parameters on resulting class") {
+    trait Foo[A] {
+      def a: A
+    }
+
+    for {
+      inner <- UIO(new Foo[Int] {
+        val a = 1
+      })
+      outer <- UIO {
+        class Bar[A](@delegate foo: Foo[A])
+        new Bar[Int[(inner)
+      }
+    } yield assert(outer.a, equalTo(1))
+  }
+ */
+}

--- a/core-tests/shared/src/test/scala/zio/macros/delegate/MixSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/macros/delegate/MixSpec.scala
@@ -18,145 +18,159 @@ package zio.macros.delegate
 import zio.UIO
 import zio.test.{ DefaultRunnableSpec, assert, suite, testM }
 import zio.test.Assertion.equalTo
-import zio.test.TestAspect.ignore
 
 object MixSpec
     extends DefaultRunnableSpec(
       suite("Mix")(
-        /*
-        testM("should allow mixing of traits") {
-          trait Foo {
-            def a: Int = 1
-          }
-          trait Bar {
-            def b: Int = 2
-          }
-
-          for {
-            left  <- UIO(new Foo {})
-            right <- UIO(new Bar {})
-            mixed <- UIO(Mix[Foo, Bar].mix(left, right))
-          } yield assert(mixed.a, equalTo(1)) && assert(mixed.b, equalTo(2))
-        }, // TODO: does not compile on 2.11 only, see issue https://github.com/zio/zio-macros/issues/50
-         */
-        testM("should overwrite methods defined on both instances with the second") {
-          trait Foo {
-            def a: Int = 1
-          }
-          trait Bar extends Foo {
-            override def a = 2
-          }
-
-          for {
-            left  <- UIO(new Foo {})
-            right <- UIO(new Bar {})
-            mixed <- UIO(Mix[Foo, Bar].mix(left, right))
-          } yield assert(mixed.a, equalTo(2))
-        } @@ ignore, // TODO: fails on 2.11 only, see issue https://github.com/zio/zio-macros/issues/49
-        testM("should allow the first type to be a class") {
-          class Foo {
-            def a: Int = 1
-          }
-          trait Bar {
-            def b: Int = 2
-          }
-
-          for {
-            left  <- UIO(new Foo())
-            right <- UIO(new Bar {})
-            mixed <- UIO(Mix[Foo, Bar].mix(left, right))
-          } yield assert(mixed.a, equalTo(1)) && assert(mixed.b, equalTo(2))
-        },
-        testM("should support methods with same name") {
-          trait Foo {
-            def a(a: Int): Int
-          }
-          trait Bar {
-            def a(a: String): String
-          }
-
-          for {
-            left <- UIO(new Foo {
-                     def a(a: Int) = 1
-                   })
-            right <- UIO(new Bar {
-                      def a(a: String) = "foo"
-                    })
-            mixed <- UIO(Mix[Foo, Bar].mix(left, right))
-          } yield assert(mixed.a(1), equalTo(1)) && assert(mixed.a(""), equalTo("foo"))
-        },
-        suite("should support type aliases")(
-          testM("case 1") {
-            trait Foo {
-              def a(a: Int): Int
-            }
-            trait Bar {
-              def a(a: String): String
-            }
-            trait Baz
-            type FooBar = Foo with Bar
-
-            for {
-              left <- UIO(new Foo with Bar {
-                       def a(a: Int)    = 2
-                       def a(a: String) = "foo"
-                     })
-              right <- UIO(new Baz {})
-              mixed <- UIO(Mix[FooBar, Baz].mix(left, right))
-            } yield assert(mixed.a(1), equalTo(2)) && assert(mixed.a(""), equalTo("foo"))
-          },
-          testM("case 2") {
-            trait Foo {
-              def a(a: Int): Int
-            }
-            trait Bar {
-              def a(a: String): String
-            }
-            trait Baz
-            type FooBar = Foo with Bar
-
-            for {
-              left <- UIO(new Baz {})
-              right <- UIO(new Foo with Bar {
-                        def a(a: Int)    = 2
-                        def a(a: String) = "foo"
-                      })
-              mixed <- UIO(Mix[Baz, FooBar].mix(left, right))
-            } yield assert(mixed.a(1), equalTo(2)) && assert(mixed.a(""), equalTo("foo"))
-          }
-        ),
-        testM("should support type arguments") {
-          trait Foo[A] {
-            def a(a: Int): A
-          }
-          trait Bar {
-            def b(a: String): String
-          }
-          trait Baz
-          type FooBar = Foo[Int] with Bar
-
-          for {
-            left <- UIO(new Baz {})
-            right <- UIO(new Foo[Int] with Bar {
-                      def a(a: Int)    = 2
-                      def b(a: String) = "foo"
-                    })
-            mixed <- UIO(Mix[Baz, FooBar].mix(left, right))
-          } yield assert(mixed.a(1), equalTo(2)) && assert(mixed.b(""), equalTo("foo"))
-        },
-        testM("should allow overriding members") {
-          trait Foo {
-            def a: Int = 1
-          }
-          trait Bar
-
-          for {
-            left <- UIO(new Foo with Bar {})
-            right <- UIO(new Foo {
-                      override def a = 2
-                    })
-            mixed <- UIO(Mix[Foo with Bar, Foo].mix(left, right))
-          } yield assert(mixed.a, equalTo(2))
-        }
+        MixSuite.mixingOfTraits,
+        MixSuite.overwriteMethods,
+        MixSuite.allowFirstClass,
+        MixSuite.methodsWithSameName,
+        MixSuite.typeAliases,
+        MixSuite.typeArguments,
+        MixSuite.overridingMembers
       )
     )
+
+object MixSuite {
+
+  val mixingOfTraits = testM("should allow mixing of traits") {
+    trait Foo {
+      def a: Int = 1
+    }
+    trait Bar {
+      def b: Int = 2
+    }
+
+    for {
+      left  <- UIO(new Foo {})
+      right <- UIO(new Bar {})
+      mixed <- UIO(Mix[Foo, Bar].mix(left, right))
+    } yield assert(mixed.a, equalTo(1)) && assert(mixed.b, equalTo(2))
+  }
+
+  val overwriteMethods = testM("should overwrite methods defined on both instances with the second") {
+    trait Foo {
+      def a: Int = 1
+    }
+    trait Bar extends Foo {
+      override def a = 2
+    }
+
+    for {
+      left  <- UIO(new Foo {})
+      right <- UIO(new Bar {})
+      mixed <- UIO(Mix[Foo, Bar].mix(left, right))
+    } yield assert(mixed.a, equalTo(2))
+  }
+
+  val allowFirstClass = testM("should allow the first type to be a class") {
+    class Foo {
+      def a: Int = 1
+    }
+    trait Bar {
+      def b: Int = 2
+    }
+
+    for {
+      left  <- UIO(new Foo())
+      right <- UIO(new Bar {})
+      mixed <- UIO(Mix[Foo, Bar].mix(left, right))
+    } yield assert(mixed.a, equalTo(1)) && assert(mixed.b, equalTo(2))
+  }
+
+  val methodsWithSameName = testM("should support methods with same name") {
+    trait Foo {
+      def a(a: Int): Int
+    }
+    trait Bar {
+      def a(a: String): String
+    }
+
+    for {
+      left <- UIO(new Foo {
+               def a(a: Int) = 1
+             })
+      right <- UIO(new Bar {
+                def a(a: String) = "foo"
+              })
+      mixed <- UIO(Mix[Foo, Bar].mix(left, right))
+    } yield assert(mixed.a(1), equalTo(1)) && assert(mixed.a(""), equalTo("foo"))
+  }
+
+  val typeAliases = suite("should support type aliases")(
+    testM("case 1") {
+      trait Foo {
+        def a(a: Int): Int
+      }
+      trait Bar {
+        def a(a: String): String
+      }
+      trait Baz
+      type FooBar = Foo with Bar
+
+      for {
+        left <- UIO(new Foo with Bar {
+                 def a(a: Int)    = 2
+                 def a(a: String) = "foo"
+               })
+        right <- UIO(new Baz {})
+        mixed <- UIO(Mix[FooBar, Baz].mix(left, right))
+      } yield assert(mixed.a(1), equalTo(2)) && assert(mixed.a(""), equalTo("foo"))
+    },
+    testM("case 2") {
+      trait Foo {
+        def a(a: Int): Int
+      }
+      trait Bar {
+        def a(a: String): String
+      }
+      trait Baz
+      type FooBar = Foo with Bar
+
+      for {
+        left <- UIO(new Baz {})
+        right <- UIO(new Foo with Bar {
+                  def a(a: Int)    = 2
+                  def a(a: String) = "foo"
+                })
+        mixed <- UIO(Mix[Baz, FooBar].mix(left, right))
+      } yield assert(mixed.a(1), equalTo(2)) && assert(mixed.a(""), equalTo("foo"))
+    }
+  )
+
+  val typeArguments = testM("should support type arguments") {
+    trait Foo[A] {
+      def a(a: Int): A
+    }
+    trait Bar {
+      def b(a: String): String
+    }
+    trait Baz
+    type FooBar = Foo[Int] with Bar
+
+    for {
+      left <- UIO(new Baz {})
+      right <- UIO(new Foo[Int] with Bar {
+                def a(a: Int)    = 2
+                def b(a: String) = "foo"
+              })
+      mixed <- UIO(Mix[Baz, FooBar].mix(left, right))
+    } yield assert(mixed.a(1), equalTo(2)) && assert(mixed.b(""), equalTo("foo"))
+  }
+
+  val overridingMembers = testM("should allow overriding members") {
+    trait Foo {
+      def a: Int = 1
+    }
+    trait Bar
+
+    for {
+      left <- UIO(new Foo with Bar {})
+      right <- UIO(new Foo {
+                override def a = 2
+              })
+      mixed <- UIO(Mix[Foo with Bar, Foo].mix(left, right))
+    } yield assert(mixed.a, equalTo(2))
+  }
+}


### PR DESCRIPTION
zio-macros has unique tests that define a lot of local traits.

To workaround bugs in Scala 2.11 related to trait encoding and
lambda-lift interaction, we factor the tests out into objects.