### PR TITLE
Archive repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 | --- | --- | --- | --- |
 | [![Build Status][badge-ci]][link-ci] | [![Release Artifacts][badge-sonatype]][link-sonatype] | [![Average time to resolve an issue][badge-iim]][link-iim] | [![badge-discord]][link-discord] |
 
+---
+## Zio-macros has been moved into [ZIO Core](https://github.com/zio/zio). This repo will no longer be maintained.
+---
+
 Scrap boilerplate in your ZIO projects.
 Learn more about ZIO at:
 


### PR DESCRIPTION
With `@Accessible` macro migration to `zio/zio` PR [#3122](https://github.com/zio/zio/pull/3122), `@Mockable` already merged, and `@delegate` family obsoleted, so its time to archive this repository.

